### PR TITLE
Fix reply when msg is deleted

### DIFF
--- a/autoroom/pcx_lib.py
+++ b/autoroom/pcx_lib.py
@@ -43,14 +43,17 @@ async def reply(ctx: commands.Context, content: Any = None, **kwargs: Any):
         ):
             mention_author = kwargs.pop("mention_author", False)
             kwargs.update(mention_author=mention_author)
-            await ctx.reply(content=content, **kwargs)
-        else:
-            allowed_mentions = kwargs.pop(
-                "allowed_mentions",
-                discord.AllowedMentions(users=False),
-            )
-            kwargs.update(allowed_mentions=allowed_mentions)
-            await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
+            try:
+                await ctx.reply(content=content, **kwargs)
+                return
+            except discord.HTTPException:
+                pass
+        allowed_mentions = kwargs.pop(
+            "allowed_mentions",
+            discord.AllowedMentions(users=False),
+        )
+        kwargs.update(allowed_mentions=allowed_mentions)
+        await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
     else:
         await ctx.send(content=content, **kwargs)
 

--- a/bancheck/pcx_lib.py
+++ b/bancheck/pcx_lib.py
@@ -43,14 +43,17 @@ async def reply(ctx: commands.Context, content: Any = None, **kwargs: Any):
         ):
             mention_author = kwargs.pop("mention_author", False)
             kwargs.update(mention_author=mention_author)
-            await ctx.reply(content=content, **kwargs)
-        else:
-            allowed_mentions = kwargs.pop(
-                "allowed_mentions",
-                discord.AllowedMentions(users=False),
-            )
-            kwargs.update(allowed_mentions=allowed_mentions)
-            await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
+            try:
+                await ctx.reply(content=content, **kwargs)
+                return
+            except discord.HTTPException:
+                pass
+        allowed_mentions = kwargs.pop(
+            "allowed_mentions",
+            discord.AllowedMentions(users=False),
+        )
+        kwargs.update(allowed_mentions=allowed_mentions)
+        await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
     else:
         await ctx.send(content=content, **kwargs)
 

--- a/decodebinary/pcx_lib.py
+++ b/decodebinary/pcx_lib.py
@@ -43,14 +43,17 @@ async def reply(ctx: commands.Context, content: Any = None, **kwargs: Any):
         ):
             mention_author = kwargs.pop("mention_author", False)
             kwargs.update(mention_author=mention_author)
-            await ctx.reply(content=content, **kwargs)
-        else:
-            allowed_mentions = kwargs.pop(
-                "allowed_mentions",
-                discord.AllowedMentions(users=False),
-            )
-            kwargs.update(allowed_mentions=allowed_mentions)
-            await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
+            try:
+                await ctx.reply(content=content, **kwargs)
+                return
+            except discord.HTTPException:
+                pass
+        allowed_mentions = kwargs.pop(
+            "allowed_mentions",
+            discord.AllowedMentions(users=False),
+        )
+        kwargs.update(allowed_mentions=allowed_mentions)
+        await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
     else:
         await ctx.send(content=content, **kwargs)
 

--- a/dice/pcx_lib.py
+++ b/dice/pcx_lib.py
@@ -43,14 +43,17 @@ async def reply(ctx: commands.Context, content: Any = None, **kwargs: Any):
         ):
             mention_author = kwargs.pop("mention_author", False)
             kwargs.update(mention_author=mention_author)
-            await ctx.reply(content=content, **kwargs)
-        else:
-            allowed_mentions = kwargs.pop(
-                "allowed_mentions",
-                discord.AllowedMentions(users=False),
-            )
-            kwargs.update(allowed_mentions=allowed_mentions)
-            await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
+            try:
+                await ctx.reply(content=content, **kwargs)
+                return
+            except discord.HTTPException:
+                pass
+        allowed_mentions = kwargs.pop(
+            "allowed_mentions",
+            discord.AllowedMentions(users=False),
+        )
+        kwargs.update(allowed_mentions=allowed_mentions)
+        await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
     else:
         await ctx.send(content=content, **kwargs)
 

--- a/heartbeat/pcx_lib.py
+++ b/heartbeat/pcx_lib.py
@@ -43,14 +43,17 @@ async def reply(ctx: commands.Context, content: Any = None, **kwargs: Any):
         ):
             mention_author = kwargs.pop("mention_author", False)
             kwargs.update(mention_author=mention_author)
-            await ctx.reply(content=content, **kwargs)
-        else:
-            allowed_mentions = kwargs.pop(
-                "allowed_mentions",
-                discord.AllowedMentions(users=False),
-            )
-            kwargs.update(allowed_mentions=allowed_mentions)
-            await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
+            try:
+                await ctx.reply(content=content, **kwargs)
+                return
+            except discord.HTTPException:
+                pass
+        allowed_mentions = kwargs.pop(
+            "allowed_mentions",
+            discord.AllowedMentions(users=False),
+        )
+        kwargs.update(allowed_mentions=allowed_mentions)
+        await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
     else:
         await ctx.send(content=content, **kwargs)
 

--- a/reactchannel/pcx_lib.py
+++ b/reactchannel/pcx_lib.py
@@ -43,14 +43,17 @@ async def reply(ctx: commands.Context, content: Any = None, **kwargs: Any):
         ):
             mention_author = kwargs.pop("mention_author", False)
             kwargs.update(mention_author=mention_author)
-            await ctx.reply(content=content, **kwargs)
-        else:
-            allowed_mentions = kwargs.pop(
-                "allowed_mentions",
-                discord.AllowedMentions(users=False),
-            )
-            kwargs.update(allowed_mentions=allowed_mentions)
-            await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
+            try:
+                await ctx.reply(content=content, **kwargs)
+                return
+            except discord.HTTPException:
+                pass
+        allowed_mentions = kwargs.pop(
+            "allowed_mentions",
+            discord.AllowedMentions(users=False),
+        )
+        kwargs.update(allowed_mentions=allowed_mentions)
+        await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
     else:
         await ctx.send(content=content, **kwargs)
 

--- a/remindme/pcx_lib.py
+++ b/remindme/pcx_lib.py
@@ -43,14 +43,17 @@ async def reply(ctx: commands.Context, content: Any = None, **kwargs: Any):
         ):
             mention_author = kwargs.pop("mention_author", False)
             kwargs.update(mention_author=mention_author)
-            await ctx.reply(content=content, **kwargs)
-        else:
-            allowed_mentions = kwargs.pop(
-                "allowed_mentions",
-                discord.AllowedMentions(users=False),
-            )
-            kwargs.update(allowed_mentions=allowed_mentions)
-            await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
+            try:
+                await ctx.reply(content=content, **kwargs)
+                return
+            except discord.HTTPException:
+                pass
+        allowed_mentions = kwargs.pop(
+            "allowed_mentions",
+            discord.AllowedMentions(users=False),
+        )
+        kwargs.update(allowed_mentions=allowed_mentions)
+        await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
     else:
         await ctx.send(content=content, **kwargs)
 

--- a/updatenotify/pcx_lib.py
+++ b/updatenotify/pcx_lib.py
@@ -43,14 +43,17 @@ async def reply(ctx: commands.Context, content: Any = None, **kwargs: Any):
         ):
             mention_author = kwargs.pop("mention_author", False)
             kwargs.update(mention_author=mention_author)
-            await ctx.reply(content=content, **kwargs)
-        else:
-            allowed_mentions = kwargs.pop(
-                "allowed_mentions",
-                discord.AllowedMentions(users=False),
-            )
-            kwargs.update(allowed_mentions=allowed_mentions)
-            await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
+            try:
+                await ctx.reply(content=content, **kwargs)
+                return
+            except discord.HTTPException:
+                pass
+        allowed_mentions = kwargs.pop(
+            "allowed_mentions",
+            discord.AllowedMentions(users=False),
+        )
+        kwargs.update(allowed_mentions=allowed_mentions)
+        await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
     else:
         await ctx.send(content=content, **kwargs)
 

--- a/uwu/pcx_lib.py
+++ b/uwu/pcx_lib.py
@@ -43,14 +43,17 @@ async def reply(ctx: commands.Context, content: Any = None, **kwargs: Any):
         ):
             mention_author = kwargs.pop("mention_author", False)
             kwargs.update(mention_author=mention_author)
-            await ctx.reply(content=content, **kwargs)
-        else:
-            allowed_mentions = kwargs.pop(
-                "allowed_mentions",
-                discord.AllowedMentions(users=False),
-            )
-            kwargs.update(allowed_mentions=allowed_mentions)
-            await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
+            try:
+                await ctx.reply(content=content, **kwargs)
+                return
+            except discord.HTTPException:
+                pass
+        allowed_mentions = kwargs.pop(
+            "allowed_mentions",
+            discord.AllowedMentions(users=False),
+        )
+        kwargs.update(allowed_mentions=allowed_mentions)
+        await ctx.send(content=f"{ctx.message.author.mention} {content}", **kwargs)
     else:
         await ctx.send(content=content, **kwargs)
 


### PR DESCRIPTION
Let me know if this isn't the right way to update pcx_lib.

This probably isn't the most elegant solution but I tested it and it seems to work fine.

This is the exception that the PR is supposed to fix: 

```py
HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In message_reference: Unknown message
  File "discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "remindme/c_reminder.py", line 231, in remindme
    await self._create_reminder(ctx, time_and_optional_text)
  File "remindme/c_reminder.py", line 292, in _create_reminder
    await reply(ctx, message)
  File "remindme/pcx_lib.py", line 46, in reply
    await ctx.reply(content=content, **kwargs)
  File "discord/ext/commands/context.py", line 340, in reply
    return await self.message.reply(content, **kwargs)
  File "discord/message.py", line 1358, in reply
    return await self.channel.send(content, reference=self, **kwargs)
  File "discord/abc.py", line 1065, in send
    data = await state.http.send_message(channel.id, content, tts=tts, embed=embed,
  File "discord/http.py", line 254, in request
    raise HTTPException(r, data)
```
