### PR TITLE
remindme,wikipedia: backwards-compatible setup

### DIFF
--- a/remindme/__init__.py
+++ b/remindme/__init__.py
@@ -14,4 +14,6 @@ async def setup(bot: Red) -> None:
     """Load RemindMe cog."""
     cog = RemindMe(bot)
     await cog.initialize()
-    bot.add_cog(cog)
+    r = bot.add_cog(cog)
+    if r is not None:
+        await r

--- a/wikipedia/__init__.py
+++ b/wikipedia/__init__.py
@@ -10,7 +10,9 @@ with open(Path(__file__).parent / "info.json") as fp:
     __red_end_user_data_statement__ = json.load(fp)["end_user_data_statement"]
 
 
-def setup(bot: Red) -> None:
+async def setup(bot: Red) -> None:
     """Load Wikipedia cog."""
     cog = Wikipedia()
-    bot.add_cog(cog)
+    r = bot.add_cog(cog)
+    if r is not None:
+        await r


### PR DESCRIPTION
- Support loading remindme and wikipedia cogs both for red 3.5.x and 3.4.x.