### PR TITLE
[heartbeat] Fixed {{ping}} placeholder

### DIFF
--- a/heartbeat/heartbeat.py
+++ b/heartbeat/heartbeat.py
@@ -143,8 +143,10 @@ class Heartbeat(commands.Cog):
         if not url:
             return "No URL supplied"
         if "{{ping}}" in url:
-            ping = 0 if math.isnan(self.bot.latency) else int(self.bot.latency)
-            url = url.replace("{{ping}}", str(ping))
+            ping: float = self.bot.latency
+            if ping is None or math.isnan(ping):
+                ping = 0
+            url = url.replace("{{ping}}", f"{ping*1000:.2f}")
         last_exception = None
         retries = 3
         while retries > 0:


### PR DESCRIPTION
The placeholder did always return 0.

The docs are not very clear about how the latency is returned (only thats its a float): https://discordpy.readthedocs.io/en/latest/ext/commands/api.html?highlight=latency#discord.ext.commands.Bot.latency

I did some experimenting and figured out that the latency needs to be multiplied by 1000 to get the ms which is (aleast for me) the expected output of a latency.